### PR TITLE
Add test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 **POOPy** = **P**ollution discharge monitoring with **O**bject **O**riented **Py**thon
 
+- [Description](#description)
+- [Installation](#installation)
+  - [Dependencies](#dependencies)
+  - [API Keys](#api-keys)
+  - [Testing](#testing)
+- [Usage](#usage)
+    - [Examples](#examples)
+
+
 ## Description
 
 This is a Python package for interfacing with Event Duration Monitoring (EDM) devices maintained by English (and Welsh!) Water Companies. This package was ostensibly developed to provide the back-end for [SewageMap.co.uk](https://github.com/AlexLipp/thames-sewage) but may be generically useful for those exploring the impact of sewage discharges on rivers. Currently, `POOPy` supports data from the following water companies: 
@@ -24,23 +33,63 @@ It can be used, for example to make figures like...
 
 ## Installation
 
-**Prerequisites**:
-- [GDAL](https://gdal.org/download.html)
-    - on a Mac, install with `brew install gdal`
-
 Install this package by running the following command (replacing `[LOCAL DIRECTORY]` with the directory you wish to install the package into).
+
 
 ```bash
 git clone https://github.com/AlexLipp/POOPy.git [LOCAL DIRECTORY]
 pip install .
 ```
 
+### Dependencies
+
+The package requires standard scientific Python packages (e.g. `numpy`, `pandas`, `matplotlib`) as well as the following packages:
+
+- [GDAL](https://gdal.org/download.html) - Required to manipulate geospatial datasets.
+- [pytest](https://docs.pytest.org/en/stable/) - For running the test suite [_optional_, see [Testing](#testing)].
+### API Keys
+
+To access the data for the following water companies, you will need to obtain API keys from the relevant water company by registering with their developer portal: 
+
+- [Thames Water](https://data.thameswater.co.uk/s/)
+
+From these portals you will obtain `client_id` and `client_secret` keys which are required to access the datasets. `POOPy` will look for these keys in the _environment variables_ of your system. Specifically, it will look for the following variables which must be set in your system environment: 
+
+| Key                        | Environment Variable  |
+|------------------------------------|-----------------------|
+| Thames Water client ID  | `TW_CLIENT_ID`        |
+| Thames Water 'secret' ID  | `TW_CLIENT_SECRET`    |
+
+How to set these environment variables will depend on your operating system. For example, on a Unix-based system, you could add the following lines to your `.bashrc` or `.bash_profile` file: 
+
+```bash
+export TW_CLIENT_ID="your_client_id"
+export TW_CLIENT_SECRET="your_client_secret"
+```
+
+### Testing 
+
+A test script is provided in the `tests` folder. To run the tests, you will need to install the [`pytest` package](https://docs.pytest.org/en/stable/). If installed, the tests can be run from the command line by navigating to the folder in which the package is installed and simply running the command: 
+
+```bash
+pytest
+```
+This will run the tests and provide a summary of the results. If all tests pass, the package has been installed correctly and behaving as expected. 
+
+
 ## Usage
 
-Once installed, the package can be imported into Python scripts using the following command.
-
+Once installed, the package can be imported into Python scripts using standard import commands, such as:
 ```python
 import poopy
 ```
+or 
+```python
+from poopy.companies import ThamesWater
+```
 
-Some examples of use are given in the `examples` folder.
+### Examples
+
+Examples of how to use the package (using the `ThamesWater` class as an example) are given in the `examples` folder in the form of interactive python Jupyter noteboooks: 
+- [Investigating the *current* status of sewer overflow spilling](https://github.com/AlexLipp/POOPy/blob/main/examples/current_status.ipynb)
+- [Investigating the *historical* status of sewer overflow spilling](https://github.com/AlexLipp/POOPy/blob/main/examples/historical_status.ipynb)

--- a/poopy/poopy.py
+++ b/poopy/poopy.py
@@ -142,7 +142,11 @@ class Monitor:
     def discharge_in_last_48h(self) -> bool:
         # Raise a warning if the discharge_in_last_48h is not set
         if self._discharge_in_last_48h is None:
-            warnings.warn("discharge_in_last_48h is not set. Returning None.")
+            warnings.warn(
+                "\033[91m"
+                f"!ADVISORY! Information on discharges in last 48hrs could not be set for '{self.site_name}'. `.discharge_in_last_48h` attribute returns None."
+                + "\033[0m"
+            )
         return self._discharge_in_last_48h
 
     @current_event.setter
@@ -217,7 +221,7 @@ class Monitor:
         if len(events) == 0:
             warnings.warn(
                 "\033[91m"
-                + f"\n!WARNING! Monitor {self.site_name} has no recorded events. Returning None."
+                + f"\n!ADVISORY! Monitor '{self.site_name}' has no recorded events. Returning None."
                 + "\033[0m"
             )
 
@@ -502,7 +506,7 @@ class Event(ABC):
         if self._start_time is None:
             warnings.warn(
                 "\033[91m"
-                + "!WARNING! Event has no start time. Returning None."
+                + f"!ADVISORY! For {self.event_type} event for '{self.monitor.site_name}' (in {self.monitor.water_company.name}) start time information is not available. `start_time` attribute returns None."
                 + "\033[0m"
             )
         return self._start_time
@@ -514,7 +518,7 @@ class Event(ABC):
         if self._ongoing:
             warnings.warn(
                 "\033[91m"
-                + "!WARNING! Event is ongoing and has no end time. Returning None."
+                + f"!ADVISORY! This {self.event_type} event for '{self.monitor.site_name}' (in {self.monitor.water_company.name}) is ongoing. `end_time` attribute returns None."
                 + "\033[0m"
             )
         return self._end_time
@@ -703,7 +707,6 @@ class WaterCompany(ABC):
         This is all handled by the pooch package. The hash of the file is checked against the known hash to ensure the file is not corrupted.
         If the file is already present in the pooch cache, it will not be downloaded again.
         """
-        print("\033[94m" + "Fetching D8 file from Zenodo source..." + "\033[0m")
         file_path = pooch.retrieve(url=url, known_hash=known_hash)
 
         return file_path

--- a/tests/test_watercompanies.py
+++ b/tests/test_watercompanies.py
@@ -1,0 +1,143 @@
+import datetime
+import os
+import warnings
+
+from numpy import isnan
+
+from poopy.companies import ThamesWater, WelshWater
+from poopy.poopy import Monitor, WaterCompany, Event
+
+# Retrieve Thames Water API credentials from environment variables
+TW_CLIENTID = os.getenv("TW_CLIENT_ID")
+TW_CLIENTSECRET = os.getenv("TW_CLIENT_SECRET")
+
+if TW_CLIENTID is None or TW_CLIENTSECRET is None:
+    raise ValueError(
+        "Thames Water API keys are missing from the environment!\n Please set them and try again."
+    )
+
+
+def check_current_event_init(current: Event, monitor: Monitor):
+    """
+    Tests the initialization of the (current) event attribute w.r.t the Monitor object it belongs to
+
+    Args:
+        current: Event object
+        monitor: The monitor object to which the event belongs.
+    """
+    # assert that the event belongs to the monitor
+    assert current.monitor == monitor
+    # assert that the event is ongoing (as current event is always ongoing)
+    assert current.ongoing
+    # assert that current.end_time is not None (as the current event is always ongoing)
+    # ignore the advisory warning that is raised when the end_time is None for ongoing events (as it should be)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert current.end_time is None
+
+    # assert that current.event_type is either "Discharging", "Offline", or "Not Discharging"
+    assert current.event_type in ["Discharging", "Offline", "Not Discharging"]
+
+    if current.start_time is not None:
+        # Check that the start time is in the past
+        assert current.start_time < datetime.datetime.now()
+        # Assert that the duration is close to the current time minus the start time
+        expct_duration = datetime.datetime.now() - current.start_time
+        assert abs(current.duration - expct_duration.total_seconds() / 60) < 5
+    else:
+        # Check that the duration is NaN if the start time is None
+        assert isnan(current.duration)
+
+
+def check_monitor(monitor: Monitor, wc: WaterCompany):
+    """
+    Tests the initialization of a Monitor object w.r.t the WaterCompany object it belongs to
+
+    Args:
+        monitor: The monitor object to be tested.
+        wc: The water company object to which the monitor belongs.
+
+    """
+
+    # assert that the monitor belongs to the water company
+    assert monitor.water_company == wc
+    # assert that monitor is within the extent of the accumulator domain
+    assert wc.accumulator.extent[0] <= monitor.x_coord <= wc.accumulator.extent[1]
+    assert wc.accumulator.extent[2] <= monitor.y_coord <= wc.accumulator.extent[3]
+
+    # assert that the monitor has the correct attributes
+    assert type(monitor.site_name) == str
+    assert type(monitor.receiving_watercourse) == str
+    assert type(monitor.permit_number) == str
+    # assert that the monitor has a valid status
+    assert monitor.current_status in ["Discharging", "Not Discharging", "Offline"]
+
+    # Extract the current event and test it
+    current = monitor.current_event
+    check_current_event_init(current, monitor)
+
+
+def check_watercompany(wc: WaterCompany):
+    """
+    Tests the initialization of a WaterCompany object
+
+    Args:
+        wc: The water company object to be tested.
+    """
+    # Check that the D8 file is created correctly
+    assert os.path.exists(wc._d8_file_path)
+    assert os.path.isfile(wc._d8_file_path)
+
+    # Assert that the timestamp is within 1 minute of the current time (allowing for some slowness in the test)
+    assert (datetime.datetime.now() - wc._timestamp) < datetime.timedelta(minutes=1)
+    # Assert that the set of active monitor names is the same as the set of active monitors
+    assert set(wc.active_monitor_names) == set(wc.active_monitors.keys())
+
+    for monitor in wc.active_monitors.values():
+        # Assert that every monitor object passes generic checks
+        check_monitor(monitor, wc)
+
+    # Check that the discharging monitors subset is correctly being created
+    for monitor in wc.discharging_monitors:
+        assert monitor.site_name in wc.active_monitor_names
+        # Check that the monitor is discharging
+        assert monitor.current_status == "Discharging"
+        # Check that the monitor has a discharging event in the last 48 hours
+        assert monitor.discharge_in_last_48h == True
+
+    # Check that the list of recently discharging monitors is correctly being created
+    for monitor in wc.recently_discharging_monitors:
+        assert monitor.site_name in wc.active_monitor_names
+        # Check that each monitor has recorded a discharge in the last 48 hours
+        assert monitor.discharge_in_last_48h == True
+
+
+def test_thames_water_init():
+    """
+    Test the basic initialization of a ThamesWater object
+    """
+    tw = ThamesWater(TW_CLIENTID, TW_CLIENTSECRET)
+    assert tw.name == "ThamesWater"
+    assert tw.clientID == TW_CLIENTID
+    assert tw.clientSecret == TW_CLIENTSECRET
+
+    # Check that the accumulator is initialized correctly with the correct extent (in OSGB)
+    assert tw.accumulator.extent == [319975.0, 620025.0, 79975.0, 280025.0]
+    # Now test the rest of the object which is common to all WaterCompany objects
+    check_watercompany(tw)
+
+
+def test_welsh_water_init():
+    """
+    Test the basic initialization of a WelshWater object
+    """
+
+    ww = WelshWater()
+    assert ww.name == "WelshWater"
+    assert ww.clientID == ""
+    assert ww.clientSecret == ""
+
+    # Check that the accumulator is initialized correctly with the correct extent (in OSGB)
+    assert ww.accumulator.extent == [159975.0, 499975.0, 160025.0, 400025.0]
+    # Now test the rest of the object which is common to all WaterCompany objects
+    check_watercompany(ww)


### PR DESCRIPTION
Adds a pytest script which checks that `ThamesWater` and `WelshWater` classes are being initiated correctly. Note that this does not test the accuracy of the data being received from the APIs, simply that it is *internally* consistent. Additionally, we update the README and some of the warning messages returned.