### PR TITLE
Update accumulator to return coordinates of centre of cell 

### DIFF
--- a/poopy/cfuncs.pyx
+++ b/poopy/cfuncs.pyx
@@ -380,7 +380,7 @@ cpdef (int, int) ItoXY(int i, int ncols):
 @cython.wraparound(False)   # Deactivate negative indexing.
 cpdef vector[float] XYtocoords(int x, int y, float dx, float dy, float ULx, float ULy):
     """
-    Converts a pair of col, row indices to a pair of geospatial x, y coordinates.
+    Converts a pair of col, row indices to a pair of geospatial x, y coordinates for the center of the cell.
 
     Args:
         x: The column index.
@@ -394,8 +394,9 @@ cpdef vector[float] XYtocoords(int x, int y, float dx, float dy, float ULx, floa
         The x, y coordinate pair.
     """
     cdef vector[float] coords
-    cdef float cx = ULx + x * dx
-    cdef float cy = ULy + y * dy
+    # Calculate the center coordinates of the cell (which is dx/2, dy/2 from the upper left corner)
+    cdef float cx = (ULx + x * dx) + dx / 2
+    cdef float cy = (ULy + y * dy) + dy / 2
     coords.push_back(cx)
     coords.push_back(cy)
     return coords

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extensions = [
 
 setup(
     name="poopy",
-    version="0.2.1",
+    version="0.2.2",
     ext_modules=cythonize(extensions),
     include_dirs=[numpy.get_include()],
     packages=find_packages(),


### PR DESCRIPTION
Previously, the `accumulator` object returned the coordinates of the upper-left corner of a pixel in keeping with GDAL convention. However, it is more appropriate that when returning linestrings or points, the returned coordinates are for the centre of the cell. As a result, I have updated the script to shift the output coordinates by a value of `dx/2` and `dy/2` so that all outputs are at the centre of the raster cell.