### PR TITLE
Changes to handle Thames Water API v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,26 +62,6 @@ git clone https://github.com/AlexLipp/POOPy.git [LOCAL DIRECTORY]
 pip install .
 ```
 
-### API Keys
-
-To access the data for the following water companies, you will need to obtain API keys from the relevant water company by registering with their developer portal: 
-
-- [Thames Water](https://data.thameswater.co.uk/s/)
-
-From these portals you will obtain `client_id` and `client_secret` keys which are required to access the datasets. `POOPy` will look for these keys in the _environment variables_ of your system. Specifically, it will look for the following variables which must be set in your system environment: 
-
-| Key                        | Environment Variable  |
-|------------------------------------|-----------------------|
-| Thames Water client ID  | `TW_CLIENT_ID`        |
-| Thames Water 'secret' ID  | `TW_CLIENT_SECRET`    |
-
-How to set these environment variables will depend on your operating system. For example, on a Unix-based system, you could add the following lines to your `.bashrc` or `.bash_profile` file: 
-
-```bash
-export TW_CLIENT_ID="your_client_id"
-export TW_CLIENT_SECRET="your_client_secret"
-```
-
 ### Testing 
 
 A test script is provided in the `tests` folder. To run the tests, you will need to install the [`pytest` package](https://docs.pytest.org/en/stable/). If installed, the tests can be run from the command line by navigating to the folder in which the package is installed and simply running the command: 

--- a/poopy/companies/thames_water.py
+++ b/poopy/companies/thames_water.py
@@ -32,7 +32,7 @@ class ThamesWater(WaterCompany):
     D8_FILE_URL = "https://zenodo.org/records/14238014/files/thames_d8.nc?download=1"
     D8_FILE_HASH = "md5:1047a14906237cd436fd483e87c1647d"
 
-    def __init__(self, client_id = "", client_secret = ""):
+    def __init__(self, client_id="", client_secret=""):
         """Initialise a Thames Water object."""
         print("\033[36m" + "Initialising Thames Water object..." + "\033[0m")
         self._name = "ThamesWater"
@@ -144,7 +144,7 @@ class ThamesWater(WaterCompany):
         params = {
             "limit": self.API_LIMIT,
             "offset": 0,
-            "locationName": monitor.site_name
+            "locationName": monitor.site_name,
         }
         df = self._handle_current_api_response(url=url, params=params, verbose=verbose)
         # Note, we use handle_current_api_response here because we want to try and fetch all records not just those up to a certain date. This
@@ -157,22 +157,22 @@ class ThamesWater(WaterCompany):
         """Transform API response so Thames v2 data remains compatible with WaterCompany class."""
         if df.empty:
             return df
-            
+
         # Map of camelCase field names to PascalCase field names
         field_mapping = {
-            'locationName': 'LocationName',
-            'permitNumber': 'PermitNumber',
-            'locationGridRef': 'LocationGridRef',
-            'x': 'X',
-            'y': 'Y',
-            'receivingWaterCourse': 'ReceivingWaterCourse',
-            'alertStatus': 'AlertStatus',
-            'statusChanged': 'StatusChange',
-            'alertPast48Hours': 'AlertPast48Hours',
-            'datetime': 'DateTime',
-            'alertType': 'AlertType'
+            "locationName": "LocationName",
+            "permitNumber": "PermitNumber",
+            "locationGridRef": "LocationGridRef",
+            "x": "X",
+            "y": "Y",
+            "receivingWaterCourse": "ReceivingWaterCourse",
+            "alertStatus": "AlertStatus",
+            "statusChanged": "StatusChange",
+            "alertPast48Hours": "AlertPast48Hours",
+            "datetime": "DateTime",
+            "alertType": "AlertType",
         }
-        
+
         # Rename columns that exist in the DataFrame
         existing_columns = set(df.columns) & set(field_mapping.keys())
         rename_dict = {col: field_mapping[col] for col in existing_columns}
@@ -206,7 +206,9 @@ class ThamesWater(WaterCompany):
                     break
                 else:
                     df_temp = pd.json_normalize(response["items"])
-                    df_temp = self._transform_api_response(df_temp) # Transform from v2 format for compatibility
+                    df_temp = self._transform_api_response(
+                        df_temp
+                    )  # Transform from v2 format for compatibility
             else:
                 raise Exception(
                     f"\tRequest failed with status code {r.status_code}, and error message: {r.json()}"
@@ -279,7 +281,9 @@ class ThamesWater(WaterCompany):
                     )
                 else:
                     df_temp = pd.json_normalize(response["items"])
-                    df_temp = self._transform_api_response(df_temp) # Transform from v2 format for compatibility
+                    df_temp = self._transform_api_response(
+                        df_temp
+                    )  # Transform from v2 format for compatibility
                     # Extract the datetime of the last record fetched and cast it to a datetime object
                     last_record_datetime = pd.to_datetime(df_temp["DateTime"].iloc[-1])
                     if last_record_datetime < self.HISTORY_VALID_UNTIL:

--- a/poopy/companies/thames_water.py
+++ b/poopy/companies/thames_water.py
@@ -14,9 +14,9 @@ from poopy.poopy import Discharge, Event, Monitor, NoDischarge, Offline, WaterCo
 class ThamesWater(WaterCompany):
     """A subclass of `WaterCompany` that represents the EDM monitoring network for Thames Water."""
 
-    API_ROOT = "https://prod-tw-opendata-app.uk-e1.cloudhub.io"
-    CURRENT_API_RESOURCE = "/data/STE/v1/DischargeCurrentStatus"
-    HISTORICAL_API_RESOURCE = "/data/STE/v1/DischargeAlerts"
+    API_ROOT = "https://api.thameswater.co.uk"
+    CURRENT_API_RESOURCE = "/opendata/v2/discharge/status"
+    HISTORICAL_API_RESOURCE = "/opendata/v2/discharge/alerts"
     API_LIMIT = 1000  # Max num of outputs that can be requested from the API at once
 
     # Set history valid until to be half past midnight on the 1st April 2022
@@ -32,7 +32,7 @@ class ThamesWater(WaterCompany):
     D8_FILE_URL = "https://zenodo.org/records/14238014/files/thames_d8.nc?download=1"
     D8_FILE_HASH = "md5:1047a14906237cd436fd483e87c1647d"
 
-    def __init__(self, client_id: str, client_secret: str):
+    def __init__(self, client_id = "", client_secret = ""):
         """Initialise a Thames Water object."""
         print("\033[36m" + "Initialising Thames Water object..." + "\033[0m")
         self._name = "ThamesWater"
@@ -144,9 +144,7 @@ class ThamesWater(WaterCompany):
         params = {
             "limit": self.API_LIMIT,
             "offset": 0,
-            "col_1": "LocationName",
-            "operand_1": "eq",
-            "value_1": monitor.site_name,
+            "locationName": monitor.site_name
         }
         df = self._handle_current_api_response(url=url, params=params, verbose=verbose)
         # Note, we use handle_current_api_response here because we want to try and fetch all records not just those up to a certain date. This
@@ -154,6 +152,31 @@ class ThamesWater(WaterCompany):
         # not ideal because it means that if the API erroneously returns an empty dataframe in place of an error message, then the function will
         # return an empty dataframe. This is the fault of the API, not this code but it is something to be aware of, and needs to be fixed.
         return df
+
+    def _transform_api_response(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Transform API response so Thames v2 data remains compatible with WaterCompany class."""
+        if df.empty:
+            return df
+            
+        # Map of camelCase field names to PascalCase field names
+        field_mapping = {
+            'locationName': 'LocationName',
+            'permitNumber': 'PermitNumber',
+            'locationGridRef': 'LocationGridRef',
+            'x': 'X',
+            'y': 'Y',
+            'receivingWaterCourse': 'ReceivingWaterCourse',
+            'alertStatus': 'AlertStatus',
+            'statusChanged': 'StatusChange',
+            'alertPast48Hours': 'AlertPast48Hours',
+            'datetime': 'DateTime',
+            'alertType': 'AlertType'
+        }
+        
+        # Rename columns that exist in the DataFrame
+        existing_columns = set(df.columns) & set(field_mapping.keys())
+        rename_dict = {col: field_mapping[col] for col in existing_columns}
+        return df.rename(columns=rename_dict)
 
     def _handle_current_api_response(
         self, url: str, params: str, verbose: bool = False
@@ -170,10 +193,6 @@ class ThamesWater(WaterCompany):
         while True:
             r = requests.get(
                 url,
-                headers={
-                    "client_id": self.client_id,
-                    "client_secret": self.client_secret,
-                },
                 params=params,
             )
 
@@ -187,6 +206,7 @@ class ThamesWater(WaterCompany):
                     break
                 else:
                     df_temp = pd.json_normalize(response["items"])
+                    df_temp = self._transform_api_response(df_temp) # Transform from v2 format for compatibility
             else:
                 raise Exception(
                     f"\tRequest failed with status code {r.status_code}, and error message: {r.json()}"
@@ -194,7 +214,6 @@ class ThamesWater(WaterCompany):
             df = pd.concat([df, df_temp])
             params["offset"] += params["limit"]  # Increment offset for the next request
         df.reset_index(drop=True, inplace=True)
-
         # Print the full dataframe to the console if verbose is set to True
         if verbose:
             print("\033[36m" + "\tPrinting full API response..." + "\033[0m")
@@ -230,10 +249,6 @@ class ThamesWater(WaterCompany):
         while True:
             r = requests.get(
                 url,
-                headers={
-                    "client_id": self.client_id,
-                    "client_secret": self.client_secret,
-                },
                 params=params,
             )
             print("\033[36m" + "\tRequesting from " + r.url + "\033[0m")
@@ -264,6 +279,7 @@ class ThamesWater(WaterCompany):
                     )
                 else:
                     df_temp = pd.json_normalize(response["items"])
+                    df_temp = self._transform_api_response(df_temp) # Transform from v2 format for compatibility
                     # Extract the datetime of the last record fetched and cast it to a datetime object
                     last_record_datetime = pd.to_datetime(df_temp["DateTime"].iloc[-1])
                     if last_record_datetime < self.HISTORY_VALID_UNTIL:

--- a/tests/test_watercompanies.py
+++ b/tests/test_watercompanies.py
@@ -29,6 +29,7 @@ from poopy.companies import (
 )
 from poopy.poopy import Event, Monitor, WaterCompany
 
+
 def check_current_event_init(current: Event, monitor: Monitor):
     """
     Test the initialization of the (current) event attribute w.r.t the Monitor object it belongs to.

--- a/tests/test_watercompanies.py
+++ b/tests/test_watercompanies.py
@@ -29,16 +29,6 @@ from poopy.companies import (
 )
 from poopy.poopy import Event, Monitor, WaterCompany
 
-# Retrieve Thames Water API credentials from environment variables
-TW_CLIENTID = os.getenv("TW_CLIENT_ID")
-TW_CLIENTSECRET = os.getenv("TW_CLIENT_SECRET")
-
-if TW_CLIENTID is None or TW_CLIENTSECRET is None:
-    raise ValueError(
-        "Thames Water API keys are missing from the environment!\n Please set them and try again."
-    )
-
-
 def check_current_event_init(current: Event, monitor: Monitor):
     """
     Test the initialization of the (current) event attribute w.r.t the Monitor object it belongs to.
@@ -166,10 +156,10 @@ def check_watercompany(wc: WaterCompany):
 
 def test_thames_water_init():
     """Test the basic initialization of a ThamesWater object."""
-    tw = ThamesWater(TW_CLIENTID, TW_CLIENTSECRET)
+    tw = ThamesWater()
     assert tw.name == "ThamesWater"
-    assert tw.client_id == TW_CLIENTID
-    assert tw.client_secret == TW_CLIENTSECRET
+    assert tw.client_id == ""
+    assert tw.client_secret == ""
 
     # Check that the accumulator is initialized correctly with the correct extent (in OSGB)
     assert tw.accumulator.extent == [319975.0, 620025.0, 79975.0, 280025.0]


### PR DESCRIPTION
Thames Water has updated its API, [v2 Thames API ](https://docs.api.thameswater.co.uk/s/) with the main changes:
- No longer requires API keys
- Changes to camelCase convention throughout
- Minor changes to API request formats
### Fixes:
- Defaulted ThamesWater client_id & secret to blank strings
- Introduced `_transform_api_response` to convert dataframe from camelCase keys to the format POOPy expects
- Minor modifications to header and request parameters
- Updated tests removing assertions of TW client_id & secret environment variables
- Removed reference to TW API keys from readme
### To do:
- Update Jupyter example notebooks to remove API key requirement
### Weird issues:
- On a reinstall, I got a blocking error from cfuncs.pyx about datatype long not being a named term on line 28.  I fixed that with: `cdef long[:] receivers = np.empty(nrows * ncols, dtype=np.int_)`, but since the issue seemed sporadic/potentially to do with my environment/above my pay-grade, I have not pushed the change

All tests pass and functions in examples notebooks all working as expected.