### PR TITLE
Change breaking cython type declaration from long to int64

### DIFF
--- a/poopy/cfuncs.pyx
+++ b/poopy/cfuncs.pyx
@@ -25,7 +25,7 @@ def d8_to_receivers(np.ndarray[long, ndim=2] arr) -> long[:] :
     """
     cdef int nrows = arr.shape[0]
     cdef int ncols = arr.shape[1]
-    cdef long[:] receivers = np.empty(nrows * ncols, dtype=long)
+    cdef long[:] receivers = np.empty(nrows * ncols, dtype=np.int64)
     cdef int i, j
     cdef int cell
     for i in range(nrows):


### PR DESCRIPTION
Somehow, the cython auxiliary functions stopped working which was a major breaking change. The cause was a declaration of a python `long` when it should actually have been a `np.int64`. This has now been fixed, but, its not clear why this suddenly through an error. But, resolved now!